### PR TITLE
Choose the 'teletype' font by default, if they're installed

### DIFF
--- a/ttyemu.py
+++ b/ttyemu.py
@@ -117,7 +117,7 @@ class TkinterFrontend:
         font = tkinter.font.Font(**font)
         self.font = font
         self.font_width = font.measure('X')
-        self.font_height = font['size']*4/3
+        self.font_height = self.font_width * 10 / 6
         self.canvas = tkinter.Canvas(
             self.root,
             bg=bg,

--- a/ttyemu.py
+++ b/ttyemu.py
@@ -104,7 +104,15 @@ class TkinterFrontend:
         bg='#%02x%02x%02x' % background_color()
         self.terminal = terminal
         self.root = tkinter.Tk()
-        font = tkinter.font.nametofont("TkFixedFont").actual()
+        if 'Teleprinter' in tkinter.font.families(self.root):
+            # http://www.zanzig.com/download/
+            font = tkinter.font.Font(family='Teleprinter').actual()
+            font['weight'] = 'bold'
+        elif 'TELETYPE 1945-1985' in tkinter.font.families(self.root):
+            # https://www.dafont.com/teletype-1945-1985.font
+            font = tkinter.font.Font(family='TELETYPE 1945-1985').actual()
+        else:
+            font = tkinter.font.nametofont('TkFixedFont').actual()
         font['size'] = 16
         font = tkinter.font.Font(**font)
         self.font = font


### PR DESCRIPTION
There are a couple Teletype-style fonts,
http://www.zanzig.com/download/ - the bold one here is the default choice
https://www.dafont.com/teletype-1945-1985.font - looks good but non-ideal character mapping.

If neither are installed, default to the standard fixed font.